### PR TITLE
Map Cleaner Clean

### DIFF
--- a/Mapping Tools/Classes/BeatmapHelper/Beatmap.cs
+++ b/Mapping Tools/Classes/BeatmapHelper/Beatmap.cs
@@ -52,6 +52,8 @@ namespace Mapping_Tools.Classes.BeatmapHelper {
             foreach (string line in hitobjectLines) {
                 HitObjects.Add(new HitObject(line));
             }
+            // Sort the HitObjects
+            HitObjects = HitObjects.OrderBy(o => o.Time).ToList();
 
             CalculateSliderEndTimes();
             GiveObjectsGreenlines();

--- a/Mapping Tools/Classes/BeatmapHelper/Timing.cs
+++ b/Mapping Tools/Classes/BeatmapHelper/Timing.cs
@@ -225,8 +225,8 @@ namespace Mapping_Tools.Classes.BeatmapHelper {
                 }
                 currentLine += 1;
             }
-
-
+            // Sort the timingPoints
+            TimingPoints = timingPoints.OrderBy(o => o.Offset).ToList();
 
             return timingPoints;
         }

--- a/Mapping Tools/Classes/Tools/MapCleaner.cs
+++ b/Mapping Tools/Classes/Tools/MapCleaner.cs
@@ -1,0 +1,260 @@
+﻿using Mapping_Tools.Classes.BeatmapHelper;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mapping_Tools.Classes.Tools {
+    class MapCleaner {
+        public struct Arguments {
+            public string Path;
+            public bool VolumeSliders;
+            public bool SamplesetSliders;
+            public bool VolumeSpinners;
+            public bool RemoveSliderendMuting;
+            public bool ResnapObjects;
+            public bool ResnapBookmarks;
+            public int Snap1;
+            public int Snap2;
+            public bool RemoveUnclickableHitsounds;
+            public Arguments(string path, bool volumeSliders, bool samplesetSliders, bool volumeSpinners, bool removeSliderendMuting, bool resnapObjects, bool resnapBookmarks,
+                             int snap1, int snap2, bool removeUnclickableHitsounds) {
+                Path = path;
+                VolumeSliders = volumeSliders;
+                SamplesetSliders = samplesetSliders;
+                VolumeSpinners = volumeSpinners;
+                RemoveSliderendMuting = removeSliderendMuting;
+                ResnapObjects = resnapObjects;
+                ResnapBookmarks = resnapBookmarks;
+                Snap1 = snap1;
+                Snap2 = snap2;
+                RemoveUnclickableHitsounds = removeUnclickableHitsounds;
+            }
+        }
+
+        /// <summary>
+        /// Cleans a map.
+        /// </summary>
+        /// <param name="beatmap">The beatmap that is going to be cleaned.</param>
+        /// <param name="arguments">The arguments for how to clean the beatmap.</param>
+        /// <param name="worker">The BackgroundWorker for updating progress.</param>
+        /// <returns>Number of resnapped objects.</returns>
+        public static int CleanMap(Beatmap beatmap, Arguments arguments, BackgroundWorker worker = null) {
+            Timing timing = beatmap.BeatmapTiming;
+            Timeline timeline = beatmap.GetTimeline();
+
+            int mode = beatmap.General["Mode"].Value;
+            int objectsResnapped = 0;
+
+            // Count total stages
+            int maxStages = 11;
+
+            // Collect Kiai toggles and SV changes for mania/taiko
+            List<TimingPoint> kiaiToggles = new List<TimingPoint>();
+            List<TimingPoint> svChanges = new List<TimingPoint>();
+            bool lastKiai = false;
+            double lastSV = -100;
+            for (int i = 0; i < timing.TimingPoints.Count; i++) {
+                TimingPoint tp = timing.TimingPoints[i];
+                if (tp.Kiai != lastKiai) {
+                    kiaiToggles.Add(tp.Copy());
+                    lastKiai = tp.Kiai;
+                }
+                if (tp.Inherited) {
+                    lastSV = -100;
+                } else {
+                    if (tp.MpB != lastSV) {
+                        svChanges.Add(tp.Copy());
+                        lastSV = tp.MpB;
+                    }
+                }
+                UpdateProgressbar(worker, (double)i / timing.TimingPoints.Count, 0, maxStages);
+            }
+
+            // Resnap shit
+            if (arguments.ResnapObjects) {
+                // Resnap all objects
+                for (int i = 0; i < beatmap.HitObjects.Count; i++) {
+                    HitObject ho = beatmap.HitObjects[i];
+                    bool resnapped = ho.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
+                    if (resnapped) {
+                        objectsResnapped += 1;
+                    }
+                    ho.ResnapEnd(timing, arguments.Snap1, arguments.Snap2);
+                    UpdateProgressbar(worker, (double)i / beatmap.HitObjects.Count, 1, maxStages);
+                }
+
+                // Resnap Kiai toggles and SV changes
+                for (int i = 0; i < kiaiToggles.Count; i++) {
+                    TimingPoint tp = kiaiToggles[i];
+                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
+                    UpdateProgressbar(worker, (double)i / kiaiToggles.Count, 2, maxStages);
+                }
+                for (int i = 0; i < svChanges.Count; i++) {
+                    TimingPoint tp = svChanges[i];
+                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
+                    UpdateProgressbar(worker, (double)i / svChanges.Count, 3, maxStages);
+                }
+            }
+
+            if (arguments.ResnapBookmarks) {
+                // Resnap the bookmarks
+                List<double> newBookmarks = new List<double>();
+                List<double> bookmarks = beatmap.GetBookmarks();
+                for (int i = 0; i < bookmarks.Count; i++) {
+                    double bookmark = bookmarks[i];
+                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, arguments.Snap1, arguments.Snap2)));
+                    UpdateProgressbar(worker, (double)i / bookmarks.Count, 4, maxStages);
+                }
+                beatmap.SetBookmarks(newBookmarks);
+            }
+
+            // Maybe mute unclickable timelineobjects
+            if (arguments.RemoveUnclickableHitsounds) {
+                foreach (TimelineObject tlo in timeline.TimeLineObjects) {
+                    if (!(tlo.IsCircle || tlo.IsSliderHead || tlo.IsHoldnoteHead))  // Not clickable
+                    {
+                        tlo.FenoSampleVolume = 5;  // 5% volume mute
+                    }
+                }
+            }
+
+            // Make new timingpoints
+            List<TimingPointsChange> timingPointsChanges = new List<TimingPointsChange>();
+            // Add redlines
+            List<TimingPoint> redlines = timing.GetAllRedlines();
+            for (int i = 0; i < redlines.Count; i++) {
+                TimingPoint tp = redlines[i];
+                timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true, meter: true, inherited: true));
+                UpdateProgressbar(worker, (double)i / redlines.Count, 5, maxStages);
+            }
+            // Add SV changes for taiko and mania
+            if (mode == 1 || mode == 3) {
+                for (int i = 0; i < svChanges.Count; i++) {
+                    TimingPoint tp = svChanges[i];
+                    timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
+                    UpdateProgressbar(worker, (double)i / svChanges.Count, 6, maxStages);
+                }
+            }
+            // Add Kiai toggles
+            for (int i = 0; i < kiaiToggles.Count; i++) {
+                TimingPoint tp = kiaiToggles[i];
+                timingPointsChanges.Add(new TimingPointsChange(tp, kiai: true));
+                UpdateProgressbar(worker, (double)i / kiaiToggles.Count, 7, maxStages);
+            }
+            // Add Hitobject stuff
+            for (int i = 0; i < beatmap.HitObjects.Count; i++) {
+                HitObject ho = beatmap.HitObjects[i];
+                if (ho.IsSlider) // SV changes
+                {
+                    TimingPoint tp = ho.TP.Copy();
+                    tp.Offset = ho.Time;
+                    tp.MpB = ho.SV;
+                    timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
+                }
+                // Body hitsounds
+                bool vol = (ho.IsSlider && arguments.VolumeSliders) || (ho.IsSpinner && arguments.VolumeSpinners);
+                bool sam = (ho.IsSlider && arguments.SamplesetSliders && ho.SampleSet == 0);
+                bool ind = (ho.IsSlider && arguments.SamplesetSliders);
+                bool samplesetActuallyChanged = false;
+                foreach (TimingPoint tp in ho.BodyHitsounds) {
+                    if (tp.Volume == 5 && arguments.RemoveSliderendMuting) { vol = false; }  // Removing sliderbody silencing
+                    timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind, sampleset: sam));
+                    if (tp.SampleSet != ho.HitsoundTP.SampleSet) { samplesetActuallyChanged = arguments.SamplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
+                }
+                if (ho.IsSlider && (!samplesetActuallyChanged) && ho.SampleSet == 0)  // Case can put sampleset on sliderbody
+                {
+                    ho.SampleSet = ho.HitsoundTP.SampleSet;
+                    ho.SliderExtras = true;
+                }
+                if (ho.IsSlider && samplesetActuallyChanged) // Make it start out with the right sampleset
+                {
+                    TimingPoint tp = ho.HitsoundTP.Copy();
+                    tp.Offset = ho.Time;
+                    timingPointsChanges.Add(new TimingPointsChange(tp, sampleset: true));
+                }
+                UpdateProgressbar(worker, (double)i / beatmap.HitObjects.Count, 8, maxStages);
+            }
+            // Add timeline hitsounds
+            for (int i = 0; i < timeline.TimeLineObjects.Count; i++) {
+                TimelineObject tlo = timeline.TimeLineObjects[i];
+                // Change the samplesets in the hitobjects
+                if (tlo.Origin.IsCircle) {
+                    tlo.Origin.SampleSet = tlo.FenoSampleSet;
+                    tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
+                    if (mode == 3) {
+                        tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
+                        tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
+                    }
+                } else if (tlo.Origin.IsSlider) {
+                    tlo.Origin.EdgeHitsounds[tlo.Repeat] = tlo.GetHitsounds();
+                    tlo.Origin.EdgeSampleSets[tlo.Repeat] = tlo.FenoSampleSet;
+                    tlo.Origin.EdgeAdditionSets[tlo.Repeat] = tlo.FenoAdditionSet;
+                    tlo.Origin.SliderExtras = true;
+                    if (tlo.Origin.EdgeAdditionSets[tlo.Repeat] == tlo.Origin.EdgeSampleSets[tlo.Repeat])  // Simplify additions to auto
+                    {
+                        tlo.Origin.EdgeAdditionSets[tlo.Repeat] = 0;
+                    }
+                } else if (tlo.Origin.IsSpinner) {
+                    if (tlo.Repeat == 1) {
+                        tlo.Origin.SampleSet = tlo.FenoSampleSet;
+                        tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
+
+                    }
+                } else if (tlo.Origin.IsHoldNote) {
+                    if (tlo.Repeat == 0) {
+                        tlo.Origin.SampleSet = tlo.FenoSampleSet;
+                        tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
+                        tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
+                        tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
+                    }
+                }
+                if (tlo.Origin.AdditionSet == tlo.Origin.SampleSet)  // Simplify additions to auto
+                {
+                    tlo.Origin.AdditionSet = 0;
+                }
+                if (mode == 0 && tlo.HasHitsound) // Add greenlines for custom indexes and volumes
+                {
+                    TimingPoint tp = tlo.Origin.TP.Copy();
+                    tp.Offset = tlo.Time;
+                    tp.SampleIndex = tlo.FenoCustomIndex;
+                    tp.Volume = tlo.FenoSampleVolume;
+                    bool ind = !(tlo.Filename != "" && (tlo.IsCircle || tlo.IsHoldnoteHead || tlo.IsSpinnerEnd));  // Index doesnt have to change if custom is overridden by Filename
+                    bool vol = !(tp.Volume == 5 && arguments.RemoveSliderendMuting && (tlo.IsSliderEnd || tlo.IsSpinnerEnd));  // Remove volume change if sliderend muting or spinnerend muting
+                    timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind));
+                }
+                UpdateProgressbar(worker, (double)i / timeline.TimeLineObjects.Count, 9, maxStages);
+            }
+
+
+            // Add the new timingpoints
+            timingPointsChanges = timingPointsChanges.OrderBy(o => o.TP.Offset).ToList();
+            List<TimingPoint> newTimingPoints = new List<TimingPoint>();
+
+            for (int i = 0; i < timingPointsChanges.Count; i++) {
+                TimingPointsChange c = timingPointsChanges[i];
+                c.AddChange(newTimingPoints, timing);
+                UpdateProgressbar(worker, (double)i / timingPointsChanges.Count, 10, maxStages);
+            }
+
+            // Replace the old timingpoints
+            timing.TimingPoints = newTimingPoints;
+
+            // Complete progressbar
+            if (worker != null && worker.WorkerReportsProgress) {
+                worker.ReportProgress(100);
+            }
+
+            return objectsResnapped;
+        }
+
+        private static void UpdateProgressbar(BackgroundWorker worker, double fraction, int stage, int maxStages) {
+            // Update progressbar
+            if (worker != null && worker.WorkerReportsProgress) {
+                worker.ReportProgress((int)((fraction + stage) / maxStages * 100));
+            }
+        }
+    }
+}

--- a/Mapping Tools/Mapping_Tools.csproj
+++ b/Mapping Tools/Mapping_Tools.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Classes\SystemTools\SettingsManager.cs" />
     <Compile Include="Classes\Tools\BezierConverter.cs" />
     <Compile Include="Classes\Tools\CircleBezierPreset.cs" />
+    <Compile Include="Classes\Tools\MapCleaner.cs" />
     <Compile Include="Components\TimeLine\TimeLine.xaml.cs">
       <DependentUpon>TimeLine.xaml</DependentUpon>
     </Compile>

--- a/Mapping Tools/views/CleanerView.xaml.cs
+++ b/Mapping Tools/views/CleanerView.xaml.cs
@@ -82,211 +82,17 @@ namespace Mapping_Tools.Views {
 
         private void BackgroundLoader_DoWork(object sender, DoWorkEventArgs e) {
             var bgw = sender as BackgroundWorker;
-            Monitor_Program((Arguments) e.Argument, bgw);
+            Monitor_Program((MapCleaner.Arguments) e.Argument, bgw);
         }
 
-        private void Monitor_Program(Arguments arguments, BackgroundWorker worker) {
+        private void Monitor_Program(MapCleaner.Arguments arguments, BackgroundWorker worker) {
             Editor editor = new Editor(arguments.Path);
-            Timing timing = editor.Beatmap.BeatmapTiming;
-            Timeline timeline = editor.Beatmap.GetTimeline();
 
             List<TimingPoint> original = new List<TimingPoint>();
-            foreach( TimingPoint tp in timing.TimingPoints ) { original.Add(tp.Copy()); }
+            foreach (TimingPoint tp in editor.Beatmap.BeatmapTiming.TimingPoints) { original.Add(tp.Copy()); }
 
-            int mode = editor.Beatmap.General["Mode"].Value;
-            int num_timingPoints = editor.Beatmap.BeatmapTiming.TimingPoints.Count;
-            int objectsResnapped = 0;
-
-            // Count total stages
-            int maxStages = 11;
-
-            // Collect Kiai toggles and SV changes for mania/taiko
-            List<TimingPoint> kiaiToggles = new List<TimingPoint>();
-            List<TimingPoint> svChanges = new List<TimingPoint>();
-            bool lastKiai = false;
-            double lastSV = -100;
-            for (int i = 0; i < timing.TimingPoints.Count; i++) {
-                TimingPoint tp = timing.TimingPoints[i];
-                if (tp.Kiai != lastKiai) {
-                    kiaiToggles.Add(tp.Copy());
-                    lastKiai = tp.Kiai;
-                }
-                if (tp.Inherited) {
-                    lastSV = -100;
-                } else {
-                    if (tp.MpB != lastSV) {
-                        svChanges.Add(tp.Copy());
-                        lastSV = tp.MpB;
-                    }
-                }
-                UpdateProgressbar(worker, (double)i / timing.TimingPoints.Count, 0, maxStages);
-            }
-
-            // Resnap shit
-            if (arguments.ResnapObjects) {
-                // Resnap all objects
-                for (int i = 0; i < editor.Beatmap.HitObjects.Count; i++) {
-                    HitObject ho = editor.Beatmap.HitObjects[i];
-                    bool resnapped = ho.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
-                    if (resnapped) {
-                        objectsResnapped += 1;
-                    }
-                    ho.ResnapEnd(timing, arguments.Snap1, arguments.Snap2);
-                    UpdateProgressbar(worker, (double)i / editor.Beatmap.HitObjects.Count, 1, maxStages);
-                }
-
-                // Resnap Kiai toggles and SV changes
-                for (int i = 0; i < kiaiToggles.Count; i++) {
-                    TimingPoint tp = kiaiToggles[i];
-                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
-                    UpdateProgressbar(worker, (double)i / kiaiToggles.Count, 2, maxStages);
-                }
-                for (int i = 0; i < svChanges.Count; i++) {
-                    TimingPoint tp = svChanges[i];
-                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
-                    UpdateProgressbar(worker, (double)i / svChanges.Count, 3, maxStages);
-                }
-            }
-
-            if (arguments.ResnapBookmarks) {
-                // Resnap the bookmarks
-                List<double> newBookmarks = new List<double>();
-                List<double> bookmarks = editor.Beatmap.GetBookmarks();
-                for (int i = 0; i < bookmarks.Count; i++) {
-                    double bookmark = bookmarks[i];
-                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, arguments.Snap1, arguments.Snap2)));
-                    UpdateProgressbar(worker, (double)i / bookmarks.Count, 4, maxStages);
-                }
-                editor.Beatmap.SetBookmarks(newBookmarks);
-            }
-
-            // Maybe mute unclickable timelineobjects
-            if (arguments.RemoveUnclickableHitsounds) {
-                foreach (TimelineObject tlo in timeline.TimeLineObjects) {
-                    if (!(tlo.IsCircle || tlo.IsSliderHead || tlo.IsHoldnoteHead))  // Not clickable
-                    {
-                        tlo.FenoSampleVolume = 5;  // 5% volume mute
-                    }
-                }
-            }
-
-            // Make new timingpoints
-            List<TimingPointsChange> timingPointsChanges = new List<TimingPointsChange>();
-            // Add redlines
-            List<TimingPoint> redlines = timing.GetAllRedlines();
-            for (int i = 0; i < redlines.Count; i++) {
-                TimingPoint tp = redlines[i];
-                timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true, meter: true, inherited: true));
-                UpdateProgressbar(worker, (double)i / redlines.Count, 5, maxStages);
-            }
-            // Add SV changes for taiko and mania
-            if (mode == 1 || mode == 3) {
-                for (int i = 0; i < svChanges.Count; i++) {
-                    TimingPoint tp = svChanges[i];
-                    timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
-                    UpdateProgressbar(worker, (double)i / svChanges.Count, 6, maxStages);
-                }
-            }
-            // Add Kiai toggles
-            for (int i = 0; i < kiaiToggles.Count; i++) {
-                TimingPoint tp = kiaiToggles[i];
-                timingPointsChanges.Add(new TimingPointsChange(tp, kiai: true));
-                UpdateProgressbar(worker, (double)i / kiaiToggles.Count, 7, maxStages);
-            }
-            // Add Hitobject stuff
-            for (int i = 0; i < editor.Beatmap.HitObjects.Count; i++) {
-                HitObject ho = editor.Beatmap.HitObjects[i];
-                if (ho.IsSlider) // SV changes
-                {
-                    TimingPoint tp = ho.TP.Copy();
-                    tp.Offset = ho.Time;
-                    tp.MpB = ho.SV;
-                    timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
-                }
-                // Body hitsounds
-                bool vol = (ho.IsSlider && arguments.VolumeSliders) || (ho.IsSpinner && arguments.VolumeSpinners);
-                bool sam = (ho.IsSlider && arguments.SamplesetSliders && ho.SampleSet == 0);
-                bool ind = (ho.IsSlider && arguments.SamplesetSliders);
-                bool samplesetActuallyChanged = false;
-                foreach (TimingPoint tp in ho.BodyHitsounds) {
-                    if (tp.Volume == 5 && arguments.RemoveSliderendMuting) { vol = false; }  // Removing sliderbody silencing
-                    timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind, sampleset: sam));
-                    if (tp.SampleSet != ho.HitsoundTP.SampleSet) { samplesetActuallyChanged = arguments.SamplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
-                }
-                if (ho.IsSlider && (!samplesetActuallyChanged) && ho.SampleSet == 0)  // Case can put sampleset on sliderbody
-                {
-                    ho.SampleSet = ho.HitsoundTP.SampleSet;
-                    ho.SliderExtras = true;
-                }
-                if (ho.IsSlider && samplesetActuallyChanged) // Make it start out with the right sampleset
-                {
-                    TimingPoint tp = ho.HitsoundTP.Copy();
-                    tp.Offset = ho.Time;
-                    timingPointsChanges.Add(new TimingPointsChange(tp, sampleset: true));
-                }
-                UpdateProgressbar(worker, (double)i / editor.Beatmap.HitObjects.Count, 8, maxStages);
-            }
-            // Add timeline hitsounds
-            for (int i = 0; i < timeline.TimeLineObjects.Count; i++) {
-                TimelineObject tlo = timeline.TimeLineObjects[i];
-                // Change the samplesets in the hitobjects
-                if (tlo.Origin.IsCircle) {
-                    tlo.Origin.SampleSet = tlo.FenoSampleSet;
-                    tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-                    if (mode == 3) {
-                        tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
-                        tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
-                    }
-                } else if (tlo.Origin.IsSlider) {
-                    tlo.Origin.EdgeHitsounds[tlo.Repeat] = tlo.GetHitsounds();
-                    tlo.Origin.EdgeSampleSets[tlo.Repeat] = tlo.FenoSampleSet;
-                    tlo.Origin.EdgeAdditionSets[tlo.Repeat] = tlo.FenoAdditionSet;
-                    tlo.Origin.SliderExtras = true;
-                    if (tlo.Origin.EdgeAdditionSets[tlo.Repeat] == tlo.Origin.EdgeSampleSets[tlo.Repeat])  // Simplify additions to auto
-                    {
-                        tlo.Origin.EdgeAdditionSets[tlo.Repeat] = 0;
-                    }
-                } else if (tlo.Origin.IsSpinner) {
-                    if (tlo.Repeat == 1) {
-                        tlo.Origin.SampleSet = tlo.FenoSampleSet;
-                        tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-
-                    }
-                } else if (tlo.Origin.IsHoldNote) {
-                    if (tlo.Repeat == 0) {
-                        tlo.Origin.SampleSet = tlo.FenoSampleSet;
-                        tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-                        tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
-                        tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
-                    }
-                }
-                if (tlo.Origin.AdditionSet == tlo.Origin.SampleSet)  // Simplify additions to auto
-                {
-                    tlo.Origin.AdditionSet = 0;
-                }
-                if (mode == 0 && tlo.HasHitsound) // Add greenlines for custom indexes and volumes
-                {
-                    TimingPoint tp = tlo.Origin.TP.Copy();
-                    tp.Offset = tlo.Time;
-                    tp.SampleIndex = tlo.FenoCustomIndex;
-                    tp.Volume = tlo.FenoSampleVolume;
-                    bool ind = !(tlo.Filename != "" && (tlo.IsCircle || tlo.IsHoldnoteHead || tlo.IsSpinnerEnd));  // Index doesnt have to change if custom is overridden by Filename
-                    bool vol = !(tp.Volume == 5 && arguments.RemoveSliderendMuting && (tlo.IsSliderEnd || tlo.IsSpinnerEnd));  // Remove volume change if sliderend muting or spinnerend muting
-                    timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind));
-                }
-                UpdateProgressbar(worker, (double)i / timeline.TimeLineObjects.Count, 9, maxStages);
-            }
-
-
-            // Add the new timingpoints
-            timingPointsChanges = timingPointsChanges.OrderBy(o => o.TP.Offset).ToList();
-            List<TimingPoint> newTimingPoints = new List<TimingPoint>();
-            for (int i = 0; i < timingPointsChanges.Count; i++)
-            {
-                TimingPointsChange c = timingPointsChanges[i];
-                c.AddChange(newTimingPoints, timing);
-                UpdateProgressbar(worker, (double)i / timingPointsChanges.Count, 10, maxStages);
-            }
+            MapCleaner.CleanMap(editor.Beatmap, arguments, worker);
+            List<TimingPoint> newTimingPoints = editor.Beatmap.BeatmapTiming.TimingPoints;
 
             // Take note of all the changes
             TimingpointsChanged = new List<double>();
@@ -316,16 +122,11 @@ namespace Mapping_Tools.Views {
             TimingpointsAdded = newOffsets.Except(originalOffsets).ToList();
             EndTime_monitor = editor.Beatmap.HitObjects.Last().EndTime;
             EndOffset_monitor = editor.Beatmap.BeatmapTiming.TimingPoints.Last().Offset;
-
-            // Complete progressbar
-            if( worker != null && worker.WorkerReportsProgress ) {
-                worker.ReportProgress(100);
-            }
         }
 
         private void BackgroundWorker_DoWork(object sender, DoWorkEventArgs e) {
             var bgw = sender as BackgroundWorker;
-            e.Result = Run_Program((Arguments) e.Argument, bgw, e);
+            e.Result = Run_Program((MapCleaner.Arguments) e.Argument, bgw, e);
         }
 
         private void BackgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e) {
@@ -355,11 +156,11 @@ namespace Mapping_Tools.Views {
                 return;
             }
 
-            Arguments arguments = new Arguments(fileToCopy, (bool) VolumeSliders.IsChecked, (bool) SamplesetSliders.IsChecked,
-                                                (bool) VolumeSpinners.IsChecked, (bool) RemoveSliderendMuting.IsChecked,
-                                                (bool) ResnapObjects.IsChecked, (bool) ResnapBookmarks.IsChecked,
-                                                int.Parse(Snap1.Text.Split('/')[1]), int.Parse(Snap2.Text.Split('/')[1]),
-                                                (bool) RemoveUnclickableHitsounds.IsChecked);
+            MapCleaner.Arguments arguments = new MapCleaner.Arguments(fileToCopy, (bool) VolumeSliders.IsChecked, (bool) SamplesetSliders.IsChecked,
+                                                                      (bool) VolumeSpinners.IsChecked, (bool) RemoveSliderendMuting.IsChecked,
+                                                                      (bool) ResnapObjects.IsChecked, (bool) ResnapBookmarks.IsChecked,
+                                                                      int.Parse(Snap1.Text.Split('/')[1]), int.Parse(Snap2.Text.Split('/')[1]),
+                                                                      (bool) RemoveUnclickableHitsounds.IsChecked);
 
             backgroundWorker.RunWorkerAsync(arguments);
             backgroundLoader.RunWorkerAsync(arguments);
@@ -367,248 +168,18 @@ namespace Mapping_Tools.Views {
             start.IsEnabled = false;
         }
 
-        private struct Arguments {
-            public string Path;
-            public bool VolumeSliders;
-            public bool SamplesetSliders;
-            public bool VolumeSpinners;
-            public bool RemoveSliderendMuting;
-            public bool ResnapObjects;
-            public bool ResnapBookmarks;
-            public int Snap1;
-            public int Snap2;
-            public bool RemoveUnclickableHitsounds;
-            public Arguments(string path, bool volumeSliders, bool samplesetSliders, bool volumeSpinners, bool removeSliderendMuting, bool resnapObjects, bool resnapBookmarks,
-                             int snap1, int snap2, bool removeUnclickableHitsounds) {
-                Path = path;
-                VolumeSliders = volumeSliders;
-                SamplesetSliders = samplesetSliders;
-                VolumeSpinners = volumeSpinners;
-                RemoveSliderendMuting = removeSliderendMuting;
-                ResnapObjects = resnapObjects;
-                ResnapBookmarks = resnapBookmarks;
-                Snap1 = snap1;
-                Snap2 = snap2;
-                RemoveUnclickableHitsounds = removeUnclickableHitsounds;
-            }
-        }
-
-        private string Run_Program(Arguments arguments, BackgroundWorker worker, DoWorkEventArgs e) {
+        private string Run_Program(MapCleaner.Arguments arguments, BackgroundWorker worker, DoWorkEventArgs e) {
             Editor editor = new Editor(arguments.Path);
-            Timing timing = editor.Beatmap.BeatmapTiming;
-            Timeline timeline = editor.Beatmap.GetTimeline();
 
-            int mode = editor.Beatmap.General["Mode"].Value;
-            int num_timingPoints = editor.Beatmap.BeatmapTiming.TimingPoints.Count;
-            int objectsResnapped = 0;
-
-            // Count total stages
-            int maxStages = 11;
-
-            // Collect Kiai toggles and SV changes for mania/taiko
-            List<TimingPoint> kiaiToggles = new List<TimingPoint>();
-            List<TimingPoint> svChanges = new List<TimingPoint>();
-            bool lastKiai = false;
-            double lastSV = -100;
-            for( int i = 0; i < timing.TimingPoints.Count; i++ ) {
-                TimingPoint tp = timing.TimingPoints[i];
-                if( tp.Kiai != lastKiai ) {
-                    kiaiToggles.Add(tp.Copy());
-                    lastKiai = tp.Kiai;
-                }
-                if( tp.Inherited ) {
-                    lastSV = -100;
-                }
-                else {
-                    if( tp.MpB != lastSV ) {
-                        svChanges.Add(tp.Copy());
-                        lastSV = tp.MpB;
-                    }
-                }
-                UpdateProgressbar(worker, (double) i / timing.TimingPoints.Count, 0, maxStages);
-            }
-
-            // Resnap shit
-            if( arguments.ResnapObjects ) {
-                // Resnap all objects
-                for( int i = 0; i < editor.Beatmap.HitObjects.Count; i++ ) {
-                    HitObject ho = editor.Beatmap.HitObjects[i];
-                    bool resnapped = ho.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
-                    if( resnapped ) {
-                        objectsResnapped += 1;
-                    }
-                    ho.ResnapEnd(timing, arguments.Snap1, arguments.Snap2);
-                    UpdateProgressbar(worker, (double) i / editor.Beatmap.HitObjects.Count, 1, maxStages);
-                }
-
-                // Resnap Kiai toggles and SV changes
-                for( int i = 0; i < kiaiToggles.Count; i++ ) {
-                    TimingPoint tp = kiaiToggles[i];
-                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
-                    UpdateProgressbar(worker, (double) i / kiaiToggles.Count, 2, maxStages);
-                }
-                for( int i = 0; i < svChanges.Count; i++ ) {
-                    TimingPoint tp = svChanges[i];
-                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
-                    UpdateProgressbar(worker, (double) i / svChanges.Count, 3, maxStages);
-                }
-            }
-
-            if( arguments.ResnapBookmarks ) {
-                // Resnap the bookmarks
-                List<double> newBookmarks = new List<double>();
-                List<double> bookmarks = editor.Beatmap.GetBookmarks();
-                for( int i = 0; i < bookmarks.Count; i++ ) {
-                    double bookmark = bookmarks[i];
-                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, arguments.Snap1, arguments.Snap2)));
-                    UpdateProgressbar(worker, (double) i / bookmarks.Count, 4, maxStages);
-                }
-                editor.Beatmap.SetBookmarks(newBookmarks);
-            }
-
-            // Maybe mute unclickable timelineobjects
-            if( arguments.RemoveUnclickableHitsounds ) {
-                foreach( TimelineObject tlo in timeline.TimeLineObjects ) {
-                    if( !( tlo.IsCircle || tlo.IsSliderHead || tlo.IsHoldnoteHead ) )  // Not clickable
-                    {
-                        tlo.FenoSampleVolume = 5;  // 5% volume mute
-                    }
-                }
-            }
-
-            // Make new timingpoints
-            List<TimingPointsChange> timingPointsChanges = new List<TimingPointsChange>();
-            // Add redlines
-            List<TimingPoint> redlines = timing.GetAllRedlines();
-            for( int i = 0; i < redlines.Count; i++ ) {
-                TimingPoint tp = redlines[i];
-                timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true, meter: true, inherited: true));
-                UpdateProgressbar(worker, (double) i / redlines.Count, 5, maxStages);
-            }
-            // Add SV changes for taiko and mania
-            if( mode == 1 || mode == 3 ) {
-                for( int i = 0; i < svChanges.Count; i++ ) {
-                    TimingPoint tp = svChanges[i];
-                    timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
-                    UpdateProgressbar(worker, (double) i / svChanges.Count, 6, maxStages);
-                }
-            }
-            // Add Kiai toggles
-            for( int i = 0; i < kiaiToggles.Count; i++ ) {
-                TimingPoint tp = kiaiToggles[i];
-                timingPointsChanges.Add(new TimingPointsChange(tp, kiai: true));
-                UpdateProgressbar(worker, (double) i / kiaiToggles.Count, 7, maxStages);
-            }
-            // Add Hitobject stuff
-            for( int i = 0; i < editor.Beatmap.HitObjects.Count; i++ ) {
-                HitObject ho = editor.Beatmap.HitObjects[i];
-                if( ho.IsSlider ) // SV changes
-                {
-                    TimingPoint tp = ho.TP.Copy();
-                    tp.Offset = ho.Time;
-                    tp.MpB = ho.SV;
-                    timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
-                }
-                // Body hitsounds
-                bool vol = ( ho.IsSlider && arguments.VolumeSliders ) || ( ho.IsSpinner && arguments.VolumeSpinners );
-                bool sam = ( ho.IsSlider && arguments.SamplesetSliders && ho.SampleSet == 0 );
-                bool ind = ( ho.IsSlider && arguments.SamplesetSliders );
-                bool samplesetActuallyChanged = false;
-                foreach( TimingPoint tp in ho.BodyHitsounds ) {
-                    if( tp.Volume == 5 && arguments.RemoveSliderendMuting ) { vol = false; }  // Removing sliderbody silencing
-                    timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind, sampleset: sam));
-                    if( tp.SampleSet != ho.HitsoundTP.SampleSet ) { samplesetActuallyChanged = arguments.SamplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
-                }
-                if( ho.IsSlider && ( !samplesetActuallyChanged ) && ho.SampleSet == 0 )  // Case can put sampleset on sliderbody
-                {
-                    ho.SampleSet = ho.HitsoundTP.SampleSet;
-                    ho.SliderExtras = true;
-                }
-                if( ho.IsSlider && samplesetActuallyChanged ) // Make it start out with the right sampleset
-                {
-                    TimingPoint tp = ho.HitsoundTP.Copy();
-                    tp.Offset = ho.Time;
-                    timingPointsChanges.Add(new TimingPointsChange(tp, sampleset: true));
-                }
-                UpdateProgressbar(worker, (double) i / editor.Beatmap.HitObjects.Count, 8, maxStages);
-            }
-            // Add timeline hitsounds
-            for( int i = 0; i < timeline.TimeLineObjects.Count; i++ ) {
-                TimelineObject tlo = timeline.TimeLineObjects[i];
-                // Change the samplesets in the hitobjects
-                if( tlo.Origin.IsCircle ) {
-                    tlo.Origin.SampleSet = tlo.FenoSampleSet;
-                    tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-                    if( mode == 3 ) {
-                        tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
-                        tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
-                    }
-                }
-                else if( tlo.Origin.IsSlider ) {
-                    tlo.Origin.EdgeHitsounds[tlo.Repeat] = tlo.GetHitsounds();
-                    tlo.Origin.EdgeSampleSets[tlo.Repeat] = tlo.FenoSampleSet;
-                    tlo.Origin.EdgeAdditionSets[tlo.Repeat] = tlo.FenoAdditionSet;
-                    tlo.Origin.SliderExtras = true;
-                    if( tlo.Origin.EdgeAdditionSets[tlo.Repeat] == tlo.Origin.EdgeSampleSets[tlo.Repeat] )  // Simplify additions to auto
-                    {
-                        tlo.Origin.EdgeAdditionSets[tlo.Repeat] = 0;
-                    }
-                }
-                else if( tlo.Origin.IsSpinner ) {
-                    if( tlo.Repeat == 1 ) {
-                        tlo.Origin.SampleSet = tlo.FenoSampleSet;
-                        tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-
-                    }
-                }
-                else if( tlo.Origin.IsHoldNote ) {
-                    if( tlo.Repeat == 0 ) {
-                        tlo.Origin.SampleSet = tlo.FenoSampleSet;
-                        tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-                        tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
-                        tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
-                    }
-                }
-                if( tlo.Origin.AdditionSet == tlo.Origin.SampleSet )  // Simplify additions to auto
-                {
-                    tlo.Origin.AdditionSet = 0;
-                }
-                if( mode == 0 && tlo.HasHitsound ) // Add greenlines for custom indexes and volumes
-                {
-                    TimingPoint tp = tlo.Origin.TP.Copy();
-                    tp.Offset = tlo.Time;
-                    tp.SampleIndex = tlo.FenoCustomIndex;
-                    tp.Volume = tlo.FenoSampleVolume;
-                    bool ind = !( tlo.Filename != "" && ( tlo.IsCircle || tlo.IsHoldnoteHead || tlo.IsSpinnerEnd ) );  // Index doesnt have to change if custom is overridden by Filename
-                    bool vol = !( tp.Volume == 5 && arguments.RemoveSliderendMuting && ( tlo.IsSliderEnd || tlo.IsSpinnerEnd ) );  // Remove volume change if sliderend muting or spinnerend muting
-                    timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind));
-                }
-                UpdateProgressbar(worker, (double) i / timeline.TimeLineObjects.Count, 9, maxStages);
-            }
-
-
-            // Add the new timingpoints
-            timingPointsChanges = timingPointsChanges.OrderBy(o => o.TP.Offset).ToList();
-            List<TimingPoint> newTimingPoints = new List<TimingPoint>();
-            for( int i = 0; i < timingPointsChanges.Count; i++ ) {
-                TimingPointsChange c = timingPointsChanges[i];
-                c.AddChange(newTimingPoints, timing);
-                UpdateProgressbar(worker, (double) i / timingPointsChanges.Count, 10, maxStages);
-            }
-
-            // Replace the old timingpoints
-            timing.TimingPoints = newTimingPoints;
+            int oldTimingPointsCount = editor.Beatmap.BeatmapTiming.TimingPoints.Count;
+            int objectsResnapped = MapCleaner.CleanMap(editor.Beatmap, arguments, worker);
 
             // Save the file
             editor.SaveFile();
-
-            // Complete progressbar
-            if( worker != null && worker.WorkerReportsProgress ) {
-                worker.ReportProgress(100);
-            }
+            
 
             // Make an accurate message (Softwareporn)
-            int removed = num_timingPoints - newTimingPoints.Count;
+            int removed = oldTimingPointsCount - editor.Beatmap.BeatmapTiming.TimingPoints.Count;
             string message = "";
             if( removed < 0 ) {
                 message += "Succesfully added " + Math.Abs(removed);
@@ -629,17 +200,6 @@ namespace Mapping_Tools.Views {
                 message += " objects!";
             }
             return message;
-        }
-
-        private void UpdateProgressbar(BackgroundWorker worker, double fraction, int stage, int maxStages) {
-            // Update progressbar
-            if( worker != null && worker.WorkerReportsProgress ) {
-                worker.ReportProgress((int) ( ( fraction + stage ) / maxStages * 100 ));
-            }
-        }
-
-        public void Print(string str) {
-            Debug.WriteLine(str);
         }
     }
 }

--- a/Mapping Tools/views/CleanerView.xaml.cs
+++ b/Mapping Tools/views/CleanerView.xaml.cs
@@ -82,24 +82,11 @@ namespace Mapping_Tools.Views {
 
         private void BackgroundLoader_DoWork(object sender, DoWorkEventArgs e) {
             var bgw = sender as BackgroundWorker;
-            Monitor_Program((List<string>) e.Argument, bgw);
+            Monitor_Program((Arguments) e.Argument, bgw);
         }
 
-        private void Monitor_Program(List<string> arguments, BackgroundWorker worker) {
-
-            // Retrieve all arguments
-            string path = arguments[0];
-            bool volumeSliders = arguments[1] == "True";
-            bool samplesetSliders = arguments[2] == "True";
-            bool volumeSpinners = arguments[3] == "True";
-            bool removeSliderendMuting = arguments[4] == "True";
-            bool resnapObjects = arguments[5] == "True";
-            bool resnapBookmarks = arguments[6] == "True";
-            int snap1 = int.Parse(arguments[7].Split('/')[1]);
-            int snap2 = int.Parse(arguments[8].Split('/')[1]);
-            bool removeUnclickabeHitsounds = arguments[9] == "True";
-
-            Editor editor = new Editor(path);
+        private void Monitor_Program(Arguments arguments, BackgroundWorker worker) {
+            Editor editor = new Editor(arguments.Path);
             Timing timing = editor.Beatmap.BeatmapTiming;
             Timeline timeline = editor.Beatmap.GetTimeline();
 
@@ -118,66 +105,65 @@ namespace Mapping_Tools.Views {
             List<TimingPoint> svChanges = new List<TimingPoint>();
             bool lastKiai = false;
             double lastSV = -100;
-            for( int i = 0; i < timing.TimingPoints.Count; i++ ) {
+            for (int i = 0; i < timing.TimingPoints.Count; i++) {
                 TimingPoint tp = timing.TimingPoints[i];
-                if( tp.Kiai != lastKiai ) {
+                if (tp.Kiai != lastKiai) {
                     kiaiToggles.Add(tp.Copy());
                     lastKiai = tp.Kiai;
                 }
-                if( tp.Inherited ) {
+                if (tp.Inherited) {
                     lastSV = -100;
-                }
-                else {
-                    if( tp.MpB != lastSV ) {
+                } else {
+                    if (tp.MpB != lastSV) {
                         svChanges.Add(tp.Copy());
                         lastSV = tp.MpB;
                     }
                 }
-                UpdateProgressbar(worker, (double) i / timing.TimingPoints.Count, 0, maxStages);
+                UpdateProgressbar(worker, (double)i / timing.TimingPoints.Count, 0, maxStages);
             }
 
             // Resnap shit
-            if( resnapObjects ) {
+            if (arguments.ResnapObjects) {
                 // Resnap all objects
-                for( int i = 0; i < editor.Beatmap.HitObjects.Count; i++ ) {
+                for (int i = 0; i < editor.Beatmap.HitObjects.Count; i++) {
                     HitObject ho = editor.Beatmap.HitObjects[i];
-                    bool resnapped = ho.ResnapSelf(timing, snap1, snap2);
-                    if( resnapped ) {
+                    bool resnapped = ho.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
+                    if (resnapped) {
                         objectsResnapped += 1;
                     }
-                    ho.ResnapEnd(timing, snap1, snap2);
-                    UpdateProgressbar(worker, (double) i / editor.Beatmap.HitObjects.Count, 1, maxStages);
+                    ho.ResnapEnd(timing, arguments.Snap1, arguments.Snap2);
+                    UpdateProgressbar(worker, (double)i / editor.Beatmap.HitObjects.Count, 1, maxStages);
                 }
 
                 // Resnap Kiai toggles and SV changes
-                for( int i = 0; i < kiaiToggles.Count; i++ ) {
+                for (int i = 0; i < kiaiToggles.Count; i++) {
                     TimingPoint tp = kiaiToggles[i];
-                    tp.ResnapSelf(timing, snap1, snap2);
-                    UpdateProgressbar(worker, (double) i / kiaiToggles.Count, 2, maxStages);
+                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
+                    UpdateProgressbar(worker, (double)i / kiaiToggles.Count, 2, maxStages);
                 }
-                for( int i = 0; i < svChanges.Count; i++ ) {
+                for (int i = 0; i < svChanges.Count; i++) {
                     TimingPoint tp = svChanges[i];
-                    tp.ResnapSelf(timing, snap1, snap2);
-                    UpdateProgressbar(worker, (double) i / svChanges.Count, 3, maxStages);
+                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
+                    UpdateProgressbar(worker, (double)i / svChanges.Count, 3, maxStages);
                 }
             }
 
-            if( resnapBookmarks ) {
+            if (arguments.ResnapBookmarks) {
                 // Resnap the bookmarks
                 List<double> newBookmarks = new List<double>();
                 List<double> bookmarks = editor.Beatmap.GetBookmarks();
-                for( int i = 0; i < bookmarks.Count; i++ ) {
+                for (int i = 0; i < bookmarks.Count; i++) {
                     double bookmark = bookmarks[i];
-                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, snap1, snap2)));
-                    UpdateProgressbar(worker, (double) i / bookmarks.Count, 4, maxStages);
+                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, arguments.Snap1, arguments.Snap2)));
+                    UpdateProgressbar(worker, (double)i / bookmarks.Count, 4, maxStages);
                 }
                 editor.Beatmap.SetBookmarks(newBookmarks);
             }
 
             // Maybe mute unclickable timelineobjects
-            if( removeUnclickabeHitsounds ) {
-                foreach( TimelineObject tlo in timeline.TimeLineObjects ) {
-                    if( !( tlo.IsCircle || tlo.IsSliderHead || tlo.IsHoldnoteHead ) )  // Not clickable
+            if (arguments.RemoveUnclickableHitsounds) {
+                foreach (TimelineObject tlo in timeline.TimeLineObjects) {
+                    if (!(tlo.IsCircle || tlo.IsSliderHead || tlo.IsHoldnoteHead))  // Not clickable
                     {
                         tlo.FenoSampleVolume = 5;  // 5% volume mute
                     }
@@ -188,29 +174,29 @@ namespace Mapping_Tools.Views {
             List<TimingPointsChange> timingPointsChanges = new List<TimingPointsChange>();
             // Add redlines
             List<TimingPoint> redlines = timing.GetAllRedlines();
-            for( int i = 0; i < redlines.Count; i++ ) {
+            for (int i = 0; i < redlines.Count; i++) {
                 TimingPoint tp = redlines[i];
                 timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true, meter: true, inherited: true));
                 UpdateProgressbar(worker, (double)i / redlines.Count, 5, maxStages);
             }
             // Add SV changes for taiko and mania
-            if( mode == 1 || mode == 3 ) {
-                for( int i = 0; i < svChanges.Count; i++ ) {
+            if (mode == 1 || mode == 3) {
+                for (int i = 0; i < svChanges.Count; i++) {
                     TimingPoint tp = svChanges[i];
                     timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
                     UpdateProgressbar(worker, (double)i / svChanges.Count, 6, maxStages);
                 }
             }
             // Add Kiai toggles
-            for( int i = 0; i < kiaiToggles.Count; i++ ) {
+            for (int i = 0; i < kiaiToggles.Count; i++) {
                 TimingPoint tp = kiaiToggles[i];
                 timingPointsChanges.Add(new TimingPointsChange(tp, kiai: true));
                 UpdateProgressbar(worker, (double)i / kiaiToggles.Count, 7, maxStages);
             }
             // Add Hitobject stuff
-            for( int i = 0; i < editor.Beatmap.HitObjects.Count; i++ ) {
+            for (int i = 0; i < editor.Beatmap.HitObjects.Count; i++) {
                 HitObject ho = editor.Beatmap.HitObjects[i];
-                if( ho.IsSlider ) // SV changes
+                if (ho.IsSlider) // SV changes
                 {
                     TimingPoint tp = ho.TP.Copy();
                     tp.Offset = ho.Time;
@@ -218,81 +204,77 @@ namespace Mapping_Tools.Views {
                     timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
                 }
                 // Body hitsounds
-                bool vol = ( ho.IsSlider && volumeSliders ) || ( ho.IsSpinner && volumeSpinners );
-                bool sam = ( ho.IsSlider && samplesetSliders && ho.SampleSet == 0 );
-                bool ind = ( ho.IsSlider && samplesetSliders );
+                bool vol = (ho.IsSlider && arguments.VolumeSliders) || (ho.IsSpinner && arguments.VolumeSpinners);
+                bool sam = (ho.IsSlider && arguments.SamplesetSliders && ho.SampleSet == 0);
+                bool ind = (ho.IsSlider && arguments.SamplesetSliders);
                 bool samplesetActuallyChanged = false;
-                foreach (TimingPoint tp in ho.BodyHitsounds)
-                {
-                    if (tp.Volume == 5 && removeSliderendMuting) { vol = false; }  // Removing sliderbody silencing
+                foreach (TimingPoint tp in ho.BodyHitsounds) {
+                    if (tp.Volume == 5 && arguments.RemoveSliderendMuting) { vol = false; }  // Removing sliderbody silencing
                     timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind, sampleset: sam));
-                    if (tp.SampleSet != ho.HitsoundTP.SampleSet) { samplesetActuallyChanged = samplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
+                    if (tp.SampleSet != ho.HitsoundTP.SampleSet) { samplesetActuallyChanged = arguments.SamplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
                 }
-                if( ho.IsSlider && ( !samplesetActuallyChanged ) && ho.SampleSet == 0 )  // Case can put sampleset on sliderbody
+                if (ho.IsSlider && (!samplesetActuallyChanged) && ho.SampleSet == 0)  // Case can put sampleset on sliderbody
                 {
                     ho.SampleSet = ho.HitsoundTP.SampleSet;
                     ho.SliderExtras = true;
                 }
-                if( ho.IsSlider && samplesetActuallyChanged ) // Make it start out with the right sampleset
+                if (ho.IsSlider && samplesetActuallyChanged) // Make it start out with the right sampleset
                 {
                     TimingPoint tp = ho.HitsoundTP.Copy();
                     tp.Offset = ho.Time;
                     timingPointsChanges.Add(new TimingPointsChange(tp, sampleset: true));
                 }
-                UpdateProgressbar(worker, (double) i / editor.Beatmap.HitObjects.Count, 8, maxStages);
+                UpdateProgressbar(worker, (double)i / editor.Beatmap.HitObjects.Count, 8, maxStages);
             }
             // Add timeline hitsounds
-            for( int i = 0; i < timeline.TimeLineObjects.Count; i++ ) {
+            for (int i = 0; i < timeline.TimeLineObjects.Count; i++) {
                 TimelineObject tlo = timeline.TimeLineObjects[i];
                 // Change the samplesets in the hitobjects
-                if( tlo.Origin.IsCircle ) {
+                if (tlo.Origin.IsCircle) {
                     tlo.Origin.SampleSet = tlo.FenoSampleSet;
                     tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
-                    if( mode == 3 ) {
+                    if (mode == 3) {
                         tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
                         tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
                     }
-                }
-                else if( tlo.Origin.IsSlider ) {
+                } else if (tlo.Origin.IsSlider) {
                     tlo.Origin.EdgeHitsounds[tlo.Repeat] = tlo.GetHitsounds();
                     tlo.Origin.EdgeSampleSets[tlo.Repeat] = tlo.FenoSampleSet;
                     tlo.Origin.EdgeAdditionSets[tlo.Repeat] = tlo.FenoAdditionSet;
                     tlo.Origin.SliderExtras = true;
-                    if( tlo.Origin.EdgeAdditionSets[tlo.Repeat] == tlo.Origin.EdgeSampleSets[tlo.Repeat] )  // Simplify additions to auto
+                    if (tlo.Origin.EdgeAdditionSets[tlo.Repeat] == tlo.Origin.EdgeSampleSets[tlo.Repeat])  // Simplify additions to auto
                     {
                         tlo.Origin.EdgeAdditionSets[tlo.Repeat] = 0;
                     }
-                }
-                else if( tlo.Origin.IsSpinner ) {
-                    if( tlo.Repeat == 1 ) {
+                } else if (tlo.Origin.IsSpinner) {
+                    if (tlo.Repeat == 1) {
                         tlo.Origin.SampleSet = tlo.FenoSampleSet;
                         tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
 
                     }
-                }
-                else if( tlo.Origin.IsHoldNote ) {
-                    if( tlo.Repeat == 0 ) {
+                } else if (tlo.Origin.IsHoldNote) {
+                    if (tlo.Repeat == 0) {
                         tlo.Origin.SampleSet = tlo.FenoSampleSet;
                         tlo.Origin.AdditionSet = tlo.FenoAdditionSet;
                         tlo.Origin.CustomIndex = tlo.FenoCustomIndex;
                         tlo.Origin.SampleVolume = tlo.FenoSampleVolume;
                     }
                 }
-                if( tlo.Origin.AdditionSet == tlo.Origin.SampleSet )  // Simplify additions to auto
+                if (tlo.Origin.AdditionSet == tlo.Origin.SampleSet)  // Simplify additions to auto
                 {
                     tlo.Origin.AdditionSet = 0;
                 }
-                if( mode == 0 && tlo.HasHitsound ) // Add greenlines for custom indexes and volumes
+                if (mode == 0 && tlo.HasHitsound) // Add greenlines for custom indexes and volumes
                 {
                     TimingPoint tp = tlo.Origin.TP.Copy();
                     tp.Offset = tlo.Time;
                     tp.SampleIndex = tlo.FenoCustomIndex;
                     tp.Volume = tlo.FenoSampleVolume;
                     bool ind = !(tlo.Filename != "" && (tlo.IsCircle || tlo.IsHoldnoteHead || tlo.IsSpinnerEnd));  // Index doesnt have to change if custom is overridden by Filename
-                    bool vol = !(tp.Volume == 5 && removeSliderendMuting && (tlo.IsSliderEnd || tlo.IsSpinnerEnd));  // Remove volume change if sliderend muting or spinnerend muting
+                    bool vol = !(tp.Volume == 5 && arguments.RemoveSliderendMuting && (tlo.IsSliderEnd || tlo.IsSpinnerEnd));  // Remove volume change if sliderend muting or spinnerend muting
                     timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind));
                 }
-                UpdateProgressbar(worker, (double) i / timeline.TimeLineObjects.Count, 9, maxStages);
+                UpdateProgressbar(worker, (double)i / timeline.TimeLineObjects.Count, 9, maxStages);
             }
 
 
@@ -343,7 +325,7 @@ namespace Mapping_Tools.Views {
 
         private void BackgroundWorker_DoWork(object sender, DoWorkEventArgs e) {
             var bgw = sender as BackgroundWorker;
-            e.Result = Run_Program((List<string>) e.Argument, bgw, e);
+            e.Result = Run_Program((Arguments) e.Argument, bgw, e);
         }
 
         private void BackgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e) {
@@ -373,30 +355,46 @@ namespace Mapping_Tools.Views {
                 return;
             }
 
-            backgroundWorker.RunWorkerAsync(new List<string> {fileToCopy, VolumeSliders.IsChecked.ToString(), SamplesetSliders.IsChecked.ToString(),
-                                                    VolumeSpinners.IsChecked.ToString(), RemoveSliderendMuting.IsChecked.ToString(),
-                                                    ResnapObjects.IsChecked.ToString(), ResnapBookmarks.IsChecked.ToString(), Snap1.Text, Snap2.Text, RemoveUnclickableHitsounds.IsChecked.ToString()});
+            Arguments arguments = new Arguments(fileToCopy, (bool) VolumeSliders.IsChecked, (bool) SamplesetSliders.IsChecked,
+                                                (bool) VolumeSpinners.IsChecked, (bool) RemoveSliderendMuting.IsChecked,
+                                                (bool) ResnapObjects.IsChecked, (bool) ResnapBookmarks.IsChecked,
+                                                int.Parse(Snap1.Text.Split('/')[1]), int.Parse(Snap2.Text.Split('/')[1]),
+                                                (bool) RemoveUnclickableHitsounds.IsChecked);
 
-            backgroundLoader.RunWorkerAsync(new List<string> {fileToCopy, VolumeSliders.IsChecked.ToString(), SamplesetSliders.IsChecked.ToString(),
-                                                    VolumeSpinners.IsChecked.ToString(), RemoveSliderendMuting.IsChecked.ToString(),
-                                                    ResnapObjects.IsChecked.ToString(), ResnapBookmarks.IsChecked.ToString(), Snap1.Text, Snap2.Text, RemoveUnclickableHitsounds.IsChecked.ToString()});
+            backgroundWorker.RunWorkerAsync(arguments);
+            backgroundLoader.RunWorkerAsync(arguments);
+
             start.IsEnabled = false;
         }
 
-        private string Run_Program(List<string> arguments, BackgroundWorker worker, DoWorkEventArgs e) {
-            // Retrieve all arguments
-            string path = arguments[0];
-            bool volumeSliders = arguments[1] == "True";
-            bool samplesetSliders = arguments[2] == "True";
-            bool volumeSpinners = arguments[3] == "True";
-            bool removeSliderendMuting = arguments[4] == "True";
-            bool resnapObjects = arguments[5] == "True";
-            bool resnapBookmarks = arguments[6] == "True";
-            int snap1 = int.Parse(arguments[7].Split('/')[1]);
-            int snap2 = int.Parse(arguments[8].Split('/')[1]);
-            bool removeUnclickabeHitsounds = arguments[9] == "True";
+        private struct Arguments {
+            public string Path;
+            public bool VolumeSliders;
+            public bool SamplesetSliders;
+            public bool VolumeSpinners;
+            public bool RemoveSliderendMuting;
+            public bool ResnapObjects;
+            public bool ResnapBookmarks;
+            public int Snap1;
+            public int Snap2;
+            public bool RemoveUnclickableHitsounds;
+            public Arguments(string path, bool volumeSliders, bool samplesetSliders, bool volumeSpinners, bool removeSliderendMuting, bool resnapObjects, bool resnapBookmarks,
+                             int snap1, int snap2, bool removeUnclickableHitsounds) {
+                Path = path;
+                VolumeSliders = volumeSliders;
+                SamplesetSliders = samplesetSliders;
+                VolumeSpinners = volumeSpinners;
+                RemoveSliderendMuting = removeSliderendMuting;
+                ResnapObjects = resnapObjects;
+                ResnapBookmarks = resnapBookmarks;
+                Snap1 = snap1;
+                Snap2 = snap2;
+                RemoveUnclickableHitsounds = removeUnclickableHitsounds;
+            }
+        }
 
-            Editor editor = new Editor(path);
+        private string Run_Program(Arguments arguments, BackgroundWorker worker, DoWorkEventArgs e) {
+            Editor editor = new Editor(arguments.Path);
             Timing timing = editor.Beatmap.BeatmapTiming;
             Timeline timeline = editor.Beatmap.GetTimeline();
 
@@ -431,45 +429,45 @@ namespace Mapping_Tools.Views {
             }
 
             // Resnap shit
-            if( resnapObjects ) {
+            if( arguments.ResnapObjects ) {
                 // Resnap all objects
                 for( int i = 0; i < editor.Beatmap.HitObjects.Count; i++ ) {
                     HitObject ho = editor.Beatmap.HitObjects[i];
-                    bool resnapped = ho.ResnapSelf(timing, snap1, snap2);
+                    bool resnapped = ho.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
                     if( resnapped ) {
                         objectsResnapped += 1;
                     }
-                    ho.ResnapEnd(timing, snap1, snap2);
+                    ho.ResnapEnd(timing, arguments.Snap1, arguments.Snap2);
                     UpdateProgressbar(worker, (double) i / editor.Beatmap.HitObjects.Count, 1, maxStages);
                 }
 
                 // Resnap Kiai toggles and SV changes
                 for( int i = 0; i < kiaiToggles.Count; i++ ) {
                     TimingPoint tp = kiaiToggles[i];
-                    tp.ResnapSelf(timing, snap1, snap2);
+                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
                     UpdateProgressbar(worker, (double) i / kiaiToggles.Count, 2, maxStages);
                 }
                 for( int i = 0; i < svChanges.Count; i++ ) {
                     TimingPoint tp = svChanges[i];
-                    tp.ResnapSelf(timing, snap1, snap2);
+                    tp.ResnapSelf(timing, arguments.Snap1, arguments.Snap2);
                     UpdateProgressbar(worker, (double) i / svChanges.Count, 3, maxStages);
                 }
             }
 
-            if( resnapBookmarks ) {
+            if( arguments.ResnapBookmarks ) {
                 // Resnap the bookmarks
                 List<double> newBookmarks = new List<double>();
                 List<double> bookmarks = editor.Beatmap.GetBookmarks();
                 for( int i = 0; i < bookmarks.Count; i++ ) {
                     double bookmark = bookmarks[i];
-                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, snap1, snap2)));
+                    newBookmarks.Add(Math.Floor(timing.Resnap(bookmark, arguments.Snap1, arguments.Snap2)));
                     UpdateProgressbar(worker, (double) i / bookmarks.Count, 4, maxStages);
                 }
                 editor.Beatmap.SetBookmarks(newBookmarks);
             }
 
             // Maybe mute unclickable timelineobjects
-            if( removeUnclickabeHitsounds ) {
+            if( arguments.RemoveUnclickableHitsounds ) {
                 foreach( TimelineObject tlo in timeline.TimeLineObjects ) {
                     if( !( tlo.IsCircle || tlo.IsSliderHead || tlo.IsHoldnoteHead ) )  // Not clickable
                     {
@@ -512,14 +510,14 @@ namespace Mapping_Tools.Views {
                     timingPointsChanges.Add(new TimingPointsChange(tp, mpb: true));
                 }
                 // Body hitsounds
-                bool vol = ( ho.IsSlider && volumeSliders ) || ( ho.IsSpinner && volumeSpinners );
-                bool sam = ( ho.IsSlider && samplesetSliders && ho.SampleSet == 0 );
-                bool ind = ( ho.IsSlider && samplesetSliders );
+                bool vol = ( ho.IsSlider && arguments.VolumeSliders ) || ( ho.IsSpinner && arguments.VolumeSpinners );
+                bool sam = ( ho.IsSlider && arguments.SamplesetSliders && ho.SampleSet == 0 );
+                bool ind = ( ho.IsSlider && arguments.SamplesetSliders );
                 bool samplesetActuallyChanged = false;
                 foreach( TimingPoint tp in ho.BodyHitsounds ) {
-                    if( tp.Volume == 5 && removeSliderendMuting ) { vol = false; }  // Removing sliderbody silencing
+                    if( tp.Volume == 5 && arguments.RemoveSliderendMuting ) { vol = false; }  // Removing sliderbody silencing
                     timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind, sampleset: sam));
-                    if( tp.SampleSet != ho.HitsoundTP.SampleSet ) { samplesetActuallyChanged = samplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
+                    if( tp.SampleSet != ho.HitsoundTP.SampleSet ) { samplesetActuallyChanged = arguments.SamplesetSliders && ho.SampleSet == 0; }  // True for sampleset change in sliderbody
                 }
                 if( ho.IsSlider && ( !samplesetActuallyChanged ) && ho.SampleSet == 0 )  // Case can put sampleset on sliderbody
                 {
@@ -582,7 +580,7 @@ namespace Mapping_Tools.Views {
                     tp.SampleIndex = tlo.FenoCustomIndex;
                     tp.Volume = tlo.FenoSampleVolume;
                     bool ind = !( tlo.Filename != "" && ( tlo.IsCircle || tlo.IsHoldnoteHead || tlo.IsSpinnerEnd ) );  // Index doesnt have to change if custom is overridden by Filename
-                    bool vol = !( tp.Volume == 5 && removeSliderendMuting && ( tlo.IsSliderEnd || tlo.IsSpinnerEnd ) );  // Remove volume change if sliderend muting or spinnerend muting
+                    bool vol = !( tp.Volume == 5 && arguments.RemoveSliderendMuting && ( tlo.IsSliderEnd || tlo.IsSpinnerEnd ) );  // Remove volume change if sliderend muting or spinnerend muting
                     timingPointsChanges.Add(new TimingPointsChange(tp, volume: vol, index: ind));
                 }
                 UpdateProgressbar(worker, (double) i / timeline.TimeLineObjects.Count, 9, maxStages);


### PR DESCRIPTION
Moved Map Cleaner to a class so it could easily be used by other tools and significantly cleaning up the code in the Map Cleaner view.
Also made the timingpoints and hitobjects be sorted for if they are not in order in the .osu for some reason.