### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,41 @@
+---
+name: "\U0001F41B Bug report"
+about: Submit a bug report
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Prerequisites
+- [ ] I have read the [Mapping Tools FAQ](https://mappingtools.github.io/faq)
+
+## Environment
+
+<!-- The version of operating system you are using (eg Windows 8, Windows 10, etc) -->
+**OS version**: 
+
+<!-- The version of Mapping Tools you are using. You can check this by going to About -> About in the application -->
+**Mapping Tools version**: 
+
+## Description
+<!-- A clear and concise description of the bug, ie "what actually happened" -->
+
+
+### Expected behavior
+A clear and concise description of what you expected to happen
+
+### Reproduction
+<!-- Are you able to reliably reproduce this bug? If so, describe the minimal steps needed to do so -->
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. ...
+5. See error
+
+### Screenshots/Recordings
+If possible, add screenshots or screen recordings to help explain or show the problem
+
+## Additional context
+Add any other context about the problem here

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -8,6 +8,8 @@ assignees: ''
 ---
 
 ## Prerequisites
+<!-- replace the space between brackets to an `x` to "check" them -->
+
 - [ ] I have read the [Mapping Tools FAQ](https://mappingtools.github.io/faq)
 
 ## Environment

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -21,11 +21,7 @@ assignees: ''
 **Mapping Tools version**: 
 
 ## Description
-<!-- A clear and concise description of the bug, ie "what actually happened" -->
-
-
-### Expected behavior
-A clear and concise description of what you expected to happen
+A clear and concise description of the bug. What did you expect to happen, and what actually happened?
 
 ### Reproduction
 <!-- Are you able to reliably reproduce this bug? If so, describe the minimal steps needed to do so -->

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -8,6 +8,8 @@ assignees: ''
 ---
 
 ## Prerequisites
+<!-- replace the space between brackets to an `x` to "check" them -->
+
 - [ ] I have asked on the [Mapping Tools Discord](https://discord.gg/YfijKN2yjQV) and confirmed that the feature requested does not already exist in Mapping Tools
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,18 @@
+---
+name: "\U0001F4A5 Feature request"
+about: Suggest a new feature for this project
+title: "[Feature Request] "
+labels: ''
+assignees: ''
+
+---
+
+## Prerequisites
+- [ ] I have asked on the [Mapping Tools Discord](https://discord.gg/YfijKN2yjQV) and confirmed that the feature requested does not already exist in Mapping Tools
+
+## Description
+A clear and concise description of what the feature is
+
+
+## Motivation
+Outline the motivation for this feature and why it should be implemented. Has it been requested by a large amount of users? Does it address a problem that currently can't, or is difficult to, be fixed?

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -15,6 +15,5 @@ assignees: ''
 ## Description
 A clear and concise description of what the feature is
 
-
 ## Motivation
 Outline the motivation for this feature and why it should be implemented. Has it been requested by a large amount of users? Does it address a problem that currently can't, or is difficult to, be fixed?


### PR DESCRIPTION
## Motivation

The quality of GitHub issues for Mapping Tools is currently somewhat substandard. It'd be useful for everyone involved to have issue templates, to make transparent to end users what information they need to provide and ensure they are aware of refer to other, more readily available resources beforehand, and lessen the amount of time spent by maintainers asking for relevant information, redirecting people to appropriate channels, flagging duplicates, etc.

This PR introduces two basic issue templates, one for bugs and one for feature requests, that should be serviceable, at least for the time being.