### PR TITLE
Fix imported samples velocity when using SF2 files

### DIFF
--- a/Mapping_Tools/Classes/HitsoundStuff/SampleImporter.cs
+++ b/Mapping_Tools/Classes/HitsoundStuff/SampleImporter.cs
@@ -241,8 +241,8 @@ namespace Mapping_Tools.Classes.HitsoundStuff {
                     continue;
                 }
                 ushort velRange = instrumentZone.VelocityRange();
-                byte velLow = (byte)keyRange;
-                byte velHigh = (byte)(keyRange >> 8);
+                byte velLow = (byte)velRange;
+                byte velHigh = (byte)(velRange >> 8);
                 if (!(args.Velocity >= velLow && args.Velocity <= velHigh) && args.Velocity != -1 && velRange != 0) {
                     continue;
                 }


### PR DESCRIPTION
There was a small typo which made the imported samples have the wrong velocity/volume when imported, and that sometimes caused the sample not to be found on the sound font