### PR TITLE
Make export dialogs start at the same directory as the import path

### DIFF
--- a/Mapping_Tools/Viewmodels/HitsoundCopierVM.cs
+++ b/Mapping_Tools/Viewmodels/HitsoundCopierVM.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Text.Json.Serialization;
 using Mapping_Tools.Classes;
 using Mapping_Tools.Classes.BeatmapHelper;
@@ -233,7 +234,9 @@ namespace Mapping_Tools.Viewmodels {
 
             ExportBrowseCommand = new CommandImplementation(
                 _ => {
-                    string[] paths = IOHelper.BeatmapFileDialog(true, !SettingsManager.Settings.CurrentBeatmapDefaultFolder);
+                    string pathFromDirectory = Directory.GetParent(PathFrom).FullName;
+
+                    string[] paths = IOHelper.BeatmapFileDialog(pathFromDirectory, true);
                     if (paths.Length != 0) {
                         PathTo = string.Join("|", paths);
                     }

--- a/Mapping_Tools/Viewmodels/MetadataManagerVM.cs
+++ b/Mapping_Tools/Viewmodels/MetadataManagerVM.cs
@@ -2,6 +2,7 @@
 using Mapping_Tools.Classes.SystemTools;
 using Mapping_Tools.Components.Domain;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -84,7 +85,9 @@ namespace Mapping_Tools.Viewmodels {
 
             ExportBrowseCommand = new CommandImplementation(
                 _ => {
-                    var paths = IOHelper.BeatmapFileDialog(true, !SettingsManager.Settings.CurrentBeatmapDefaultFolder);
+                    string importPathDirectory = Directory.GetParent(ImportPath).FullName;
+
+                    var paths = IOHelper.BeatmapFileDialog(importPathDirectory, true);
                     if( paths.Length != 0 ) {
                         ExportPath = string.Join("|", paths);
                     }

--- a/Mapping_Tools/Viewmodels/TimingCopierVM.cs
+++ b/Mapping_Tools/Viewmodels/TimingCopierVM.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Mapping_Tools.Classes.SystemTools;
 using Mapping_Tools.Components.Domain;
 using System.ComponentModel;
@@ -56,8 +57,10 @@ namespace Mapping_Tools.Viewmodels {
 
             ExportBrowseCommand = new CommandImplementation(
                 _ => {
-                    string[] paths = IOHelper.BeatmapFileDialog(true, !SettingsManager.Settings.CurrentBeatmapDefaultFolder);
-                    if( paths.Length != 0 ) {
+                    string importPathDirectory = Directory.GetParent(ImportPath).FullName;
+                    
+                    string[] paths = IOHelper.BeatmapFileDialog(importPathDirectory, true);
+                    if ( paths.Length != 0 ) {
                         ExportPath = string.Join("|", paths);
                     }
                 });


### PR DESCRIPTION
For the tools Hitsound Copier, Metadata Manager, and Timing Copier in particular, people are usually copying from a map to another map within the same directory. With this change, the import path's parent directory is selected as the default path for the dialog.